### PR TITLE
공연 생성 및 개인 공연 조회 api

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
   generateAccessToken(payload: JwtPayload): string {
     return this.jwtService.sign(payload, {
       secret: this.configService.getOrThrow<string>('JWT_ACCESS_SECRET'),
-      expiresIn: '15m',
+      expiresIn: '30m',
     });
   }
 
@@ -115,7 +115,7 @@ export class AuthService {
       { sub: payload.sub, email: payload.email },
       {
         secret: this.configService.getOrThrow<string>('JWT_ACCESS_SECRET'),
-        expiresIn: '15m',
+        expiresIn: '30m',
       },
     );
     return { accessToken: newAccessToken };

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -125,7 +125,7 @@ export class AuthService {
     dto: RegisterUserDto,
     req: Request,
   ): Promise<{ message: string }> {
-    const user = req.user as { email: string; sub: string };
+    const user = req.user as { email: string; userId: string };
 
     const exists = await this.usersService.findByEmail(user.email);
     if (exists) {
@@ -134,6 +134,7 @@ export class AuthService {
 
     const userData = {
       email: user.email,
+      googleUid: user.userId,
       nickname: dto.nickname,
       roles: [dto.role],
       ...(dto.role === 'BAND' && { bandname: dto.bandname }),

--- a/src/performances/dto/create-performance.dto.ts
+++ b/src/performances/dto/create-performance.dto.ts
@@ -1,1 +1,0 @@
-export class CreatePerformanceDto {}

--- a/src/performances/dto/createPerformance.dto.ts
+++ b/src/performances/dto/createPerformance.dto.ts
@@ -1,0 +1,9 @@
+export class CreatePerformanceDto {
+  title: string;
+  description: string;
+  start_time: string;
+  end_time: string;
+  price: number;
+  roomId: number;
+  posterUrl: string;
+}

--- a/src/performances/dto/reservedRoom.dto.ts
+++ b/src/performances/dto/reservedRoom.dto.ts
@@ -1,0 +1,7 @@
+export class ReservedRoomDto {
+  reservationId: number;
+  roomName: string;
+  address: string;
+  startTime: Date;
+  endTime: Date;
+}

--- a/src/performances/dto/update-performance.dto.ts
+++ b/src/performances/dto/update-performance.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreatePerformanceDto } from './create-performance.dto';
-
-export class UpdatePerformanceDto extends PartialType(CreatePerformanceDto) {}

--- a/src/performances/entities/performance.entity.ts
+++ b/src/performances/entities/performance.entity.ts
@@ -16,6 +16,9 @@ export class Performance {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column()
+  posterUrl: string;
+
   @Column({ length: 100 })
   title: string;
 

--- a/src/performances/entities/performance.entity.ts
+++ b/src/performances/entities/performance.entity.ts
@@ -1,9 +1,10 @@
 import {
   Column,
+  CreateDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   OneToMany,
-  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { User } from '@/src/users/entities/user.entity';
@@ -30,10 +31,14 @@ export class Performance {
   @Column()
   price: number;
 
+  @CreateDateColumn()
+  createdAt: Date;
+
   @ManyToOne(() => User, (user) => user.performance)
+  @JoinColumn({ name: 'userId' })
   user: User;
 
-  @OneToOne(() => Room, (room) => room.performances, { nullable: true })
+  @ManyToOne(() => Room, (room) => room.performances)
   room: Room;
 
   @OneToMany(

--- a/src/performances/performance.controller.ts
+++ b/src/performances/performance.controller.ts
@@ -1,34 +1,37 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Req,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
 import { PerformanceService } from './performance.service';
-import { CreatePerformanceDto } from './dto/create-performance.dto';
-import { UpdatePerformanceDto } from './dto/update-performance.dto';
+import { JwtAuthGuard } from '@/src/auth/guards/jwt-auth.guard';
+import { Request } from 'express';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from '@/src/users/entities/user.entity';
+import { Repository } from 'typeorm';
 
-@Controller('performance')
+@Controller('performances')
 export class PerformanceController {
-  constructor(private readonly performanceService: PerformanceService) {}
-
-  @Post()
-  create(@Body() createPerformanceDto: CreatePerformanceDto) {
-    return this.performanceService.create(createPerformanceDto);
-  }
+  constructor(
+    private readonly performanceService: PerformanceService,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
 
   @Get()
-  findAll() {
-    return this.performanceService.findAll();
-  }
+  @UseGuards(JwtAuthGuard)
+  async getMyPerformances(@Req() req: Request) {
+    const googleUid = (req.user as { userId: string }).userId;
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.performanceService.findOne(+id);
-  }
+    const user = await this.userRepository.findOne({
+      where: { googleUid },
+    });
 
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updatePerformanceDto: UpdatePerformanceDto) {
-    return this.performanceService.update(+id, updatePerformanceDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.performanceService.remove(+id);
+    if (!user) {
+      throw new UnauthorizedException('등록되지 않은 사용자입니다.');
+    }
+    return this.performanceService.getMyPerformances(user.id);
   }
 }

--- a/src/performances/performance.controller.ts
+++ b/src/performances/performance.controller.ts
@@ -1,9 +1,12 @@
 import {
+  Body,
   Controller,
   Get,
+  Post,
   Req,
   UnauthorizedException,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { PerformanceService } from './performance.service';
 import { JwtAuthGuard } from '@/src/auth/guards/jwt-auth.guard';
@@ -11,6 +14,8 @@ import { Request } from 'express';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '@/src/users/entities/user.entity';
 import { Repository } from 'typeorm';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { CreatePerformanceDto } from '@/src/performances/dto/createPerformance.dto';
 
 @Controller('performances')
 export class PerformanceController {
@@ -33,5 +38,16 @@ export class PerformanceController {
       throw new UnauthorizedException('등록되지 않은 사용자입니다.');
     }
     return this.performanceService.getMyPerformances(user.id);
+  }
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(FileInterceptor('poster'))
+  async createPerformance(
+    @Body() dto: CreatePerformanceDto,
+    @Req() req: Request,
+  ) {
+    const googleUid = (req.user as { userId: string }).userId;
+    return this.performanceService.createPerformance(dto, googleUid);
   }
 }

--- a/src/performances/performance.module.ts
+++ b/src/performances/performance.module.ts
@@ -5,9 +5,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Performance } from '@/src/performances/entities/performance.entity';
 import { User } from '@/src/users/entities/user.entity';
 import { Room } from '@/src/rooms/entities/room.entity';
+import { RoomReservation } from '@/src/roomReservation/entities/roomReservation.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Performance, User, Room])],
+  imports: [
+    TypeOrmModule.forFeature([Performance, User, Room, RoomReservation]),
+  ],
   controllers: [PerformanceController],
   providers: [PerformanceService],
 })

--- a/src/performances/performance.module.ts
+++ b/src/performances/performance.module.ts
@@ -4,9 +4,10 @@ import { PerformanceController } from './performance.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Performance } from '@/src/performances/entities/performance.entity';
 import { User } from '@/src/users/entities/user.entity';
+import { Room } from '@/src/rooms/entities/room.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Performance, User])],
+  imports: [TypeOrmModule.forFeature([Performance, User, Room])],
   controllers: [PerformanceController],
   providers: [PerformanceService],
 })

--- a/src/performances/performance.module.ts
+++ b/src/performances/performance.module.ts
@@ -3,9 +3,10 @@ import { PerformanceService } from './performance.service';
 import { PerformanceController } from './performance.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Performance } from '@/src/performances/entities/performance.entity';
+import { User } from '@/src/users/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Performance])],
+  imports: [TypeOrmModule.forFeature([Performance, User])],
   controllers: [PerformanceController],
   providers: [PerformanceService],
 })

--- a/src/performances/performance.service.ts
+++ b/src/performances/performance.service.ts
@@ -1,18 +1,52 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Performance } from '@/src/performances/entities/performance.entity';
+import { CreatePerformanceDto } from '@/src/performances/dto/createPerformance.dto';
+import { User } from '@/src/users/entities/user.entity';
+import { Room } from '@/src/rooms/entities/room.entity';
 
 @Injectable()
 export class PerformanceService {
   constructor(
     @InjectRepository(Performance)
     private readonly performanceRepository: Repository<Performance>,
+
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+
+    @InjectRepository(Room)
+    private readonly roomRepository: Repository<Room>,
   ) {}
 
   async getMyPerformances(userId: number): Promise<Performance[]> {
     return this.performanceRepository.find({
       where: { user: { id: userId } },
     });
+  }
+
+  async createPerformance(dto: CreatePerformanceDto, googleUid: string) {
+    const user = await this.userRepository.findOne({ where: { googleUid } });
+    if (!user) throw new UnauthorizedException('유저 정보를 찾을 수 없습니다.');
+
+    const room = await this.roomRepository.findOne({
+      where: { id: dto.roomId },
+    });
+    if (!room)
+      throw new BadRequestException('해당 roomId의 장소를 찾을 수 없습니다');
+
+    const performance = this.performanceRepository.create({
+      ...dto,
+      start_time: new Date(dto.start_time),
+      end_time: new Date(dto.end_time),
+      user,
+      room,
+    });
+
+    return this.performanceRepository.save(performance);
   }
 }

--- a/src/performances/performance.service.ts
+++ b/src/performances/performance.service.ts
@@ -1,26 +1,18 @@
 import { Injectable } from '@nestjs/common';
-import { CreatePerformanceDto } from './dto/create-performance.dto';
-import { UpdatePerformanceDto } from './dto/update-performance.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Performance } from '@/src/performances/entities/performance.entity';
 
 @Injectable()
 export class PerformanceService {
-  create(createPerformanceDto: CreatePerformanceDto) {
-    return 'This action adds a new performances';
-  }
+  constructor(
+    @InjectRepository(Performance)
+    private readonly performanceRepository: Repository<Performance>,
+  ) {}
 
-  findAll() {
-    return `This action returns all performance`;
-  }
-
-  findOne(id: number) {
-    return `This action returns a #${id} performance`;
-  }
-
-  update(id: number, updatePerformanceDto: UpdatePerformanceDto) {
-    return `This action updates a #${id} performance`;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} performance`;
+  async getMyPerformances(userId: number): Promise<Performance[]> {
+    return this.performanceRepository.find({
+      where: { user: { id: userId } },
+    });
   }
 }

--- a/src/places/place.controller.ts
+++ b/src/places/place.controller.ts
@@ -26,13 +26,16 @@ export class PlaceController {
 
   @Get(':id')
   @UseGuards(JwtAuthGuard)
-  async getPlaceDetails(@Param('id') id: number) {
-    const place = await this.placeService.getPlaceById(id);
+  async getPlaceDetails(@Param('id') id: string) {
+    const place = await this.placeService.getPlaceById(Number(id));
 
     if (!place) {
       throw new NotFoundException('Place not found');
     }
 
-    return place;
+    return {
+      ...place,
+      businessDays: place.businessDays ?? [],
+    };
   }
 }

--- a/src/roomReservation/roomReservation.controller.ts
+++ b/src/roomReservation/roomReservation.controller.ts
@@ -1,34 +1,6 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
-import { RoomReservationService } from './roomReservation.service';
-import { CreateRoomReservationDto } from './dto/create-room-reservation.dto';
-import { UpdateRoomReservationDto } from './dto/update-room-reservation.dto';
+import { Controller } from '@nestjs/common';
 
 @Controller('roomReservation')
 export class RoomReservationController {
-  constructor(private readonly roomReservationService: RoomReservationService) {}
-
-  @Post()
-  create(@Body() createRoomReservationDto: CreateRoomReservationDto) {
-    return this.roomReservationService.create(createRoomReservationDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.roomReservationService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.roomReservationService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateRoomReservationDto: UpdateRoomReservationDto) {
-    return this.roomReservationService.update(+id, updateRoomReservationDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.roomReservationService.remove(+id);
-  }
+  constructor() {}
 }

--- a/src/roomReservation/roomReservation.service.ts
+++ b/src/roomReservation/roomReservation.service.ts
@@ -1,26 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { CreateRoomReservationDto } from './dto/create-room-reservation.dto';
-import { UpdateRoomReservationDto } from './dto/update-room-reservation.dto';
 
 @Injectable()
-export class RoomReservationService {
-  create(createRoomReservationDto: CreateRoomReservationDto) {
-    return 'This action adds a new roomReservation';
-  }
-
-  findAll() {
-    return `This action returns all roomReservation`;
-  }
-
-  findOne(id: number) {
-    return `This action returns a #${id} roomReservation`;
-  }
-
-  update(id: number, updateRoomReservationDto: UpdateRoomReservationDto) {
-    return `This action updates a #${id} roomReservation`;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} roomReservation`;
-  }
-}
+export class RoomReservationService {}

--- a/src/rooms/entities/room.entity.ts
+++ b/src/rooms/entities/room.entity.ts
@@ -36,8 +36,6 @@ export class Room {
   @OneToMany(() => RoomReservation, (reservation) => reservation.room)
   roomReservation: RoomReservation[];
 
-  @OneToOne(() => Performance, (performance) => performance.room, {
-    nullable: true,
-  })
+  @OneToMany(() => Performance, (performance) => performance.room)
   performances: Performance[];
 }

--- a/src/rooms/entities/room.entity.ts
+++ b/src/rooms/entities/room.entity.ts
@@ -3,7 +3,6 @@ import {
   Entity,
   ManyToOne,
   OneToMany,
-  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Place } from '@/src/places/entities/place.entity';

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -15,6 +15,9 @@ export class User {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column({ type: 'varchar', unique: true })
+  googleUid: string;
+
   @Column()
   nickname: string;
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -40,6 +40,7 @@ export class UsersService {
     nickname: string;
     roles: ('FAN' | 'BAND' | 'PLACE_OWNER')[];
     bandname?: string;
+    googleUid: string;
   }): Promise<User> {
     const user = this.userRepository.create(userData);
     return this.userRepository.save(user);


### PR DESCRIPTION
## 💡 개요
공연 생성 및 개인 공연 조회 api
## 📃 작업내용
공연을 생성하는 api와 개인 공연을 조회하는 api를 만들었습니다. 공연에 들어가는 포스터는 S3를 사용해야해서 다른 이슈에서 다루겠습니다
## 🔀 변경사항
performances 하위 수정
places 하위 수정
## 📸 스크린샷